### PR TITLE
style: Make editor header more compact

### DIFF
--- a/jules-scratch/verification/verify_header_style.py
+++ b/jules-scratch/verification/verify_header_style.py
@@ -1,0 +1,34 @@
+from playwright.sync_api import sync_playwright, Page, expect
+
+def verify_compact_header(page: Page):
+    """
+    This script verifies the header has been made more compact.
+    1. Navigates to the app running on the preview server.
+    2. Creates a new note to make the editor header visible.
+    3. Takes a screenshot of the editor area, focusing on the header.
+    """
+    # 1. Navigate to the app
+    # The preview server runs on port 4173 by default.
+    page.goto("http://localhost:4173")
+
+    # 2. Create a new note
+    new_note_button = page.get_by_role("button", name="New Note")
+    expect(new_note_button).to_be_visible()
+    new_note_button.click()
+
+    # Wait for the editor to be ready
+    editor_header = page.locator(".editor-header")
+    expect(editor_header).to_be_visible()
+
+    # 3. Take a screenshot of the compact header
+    page.screenshot(path="jules-scratch/verification/compact_header.png")
+
+def main():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        verify_compact_header(page)
+        browser.close()
+
+if __name__ == "__main__":
+    main()

--- a/src/lib/Editor.svelte
+++ b/src/lib/Editor.svelte
@@ -205,8 +205,8 @@
   }
 
   .editor-header {
-    padding: 1.5rem 2rem;
-    padding-left: 3.5rem; /* Add space for toggle button */
+    padding: 1rem 1.5rem;
+    padding-left: 3rem; /* Add space for toggle button */
     border-bottom: 1px solid var(--border-color);
     display: flex;
     gap: 1rem;
@@ -235,7 +235,7 @@
 
   .title-input {
     flex: 1;
-    font-size: 1.8rem;
+    font-size: 1.5rem;
     font-weight: 700;
     background: transparent;
     border: none;


### PR DESCRIPTION
Reduces the vertical padding and title font size in the editor header to create a more streamlined and space-efficient UI.

Key changes:
- Decreased padding on the `.editor-header` class in `src/lib/Editor.svelte`.
- Reduced the `font-size` of the `.title-input` class from `1.8rem` to `1.5rem`.