### PR TITLE
feat: Enhance Markdown Preview with Split-Screen and Mobile Toggle

### DIFF
--- a/jules-scratch/verification/verify_all_preview_modes.py
+++ b/jules-scratch/verification/verify_all_preview_modes.py
@@ -1,0 +1,63 @@
+from playwright.sync_api import sync_playwright, Page, expect
+
+def verify_desktop_modes(page: Page):
+    """
+    Verifies the desktop preview modes: edit -> split -> preview.
+    """
+    print("Verifying desktop modes...")
+    page.goto("http://localhost:4173")
+
+    # Create a note
+    page.get_by_role("button", name="New Note").click()
+    expect(page.locator(".editor-header")).to_be_visible()
+    page.locator(".content-textarea").fill("# Hello World\n\nThis is a test.")
+
+    # 1. Cycle to Split View
+    preview_button = page.get_by_title("Split view")
+    preview_button.click()
+    expect(page.locator(".editor-content.split-view")).to_be_visible()
+    print("Taking screenshot of split view...")
+    page.screenshot(path="jules-scratch/verification/desktop_split_view.png")
+
+    # 2. Cycle to Preview-Only View
+    preview_button = page.get_by_title("Preview-only view")
+    preview_button.click()
+    expect(page.locator(".markdown-preview-wrapper")).to_be_visible()
+    expect(page.locator(".content-textarea")).not_to_be_visible()
+    print("Taking screenshot of preview-only view...")
+    page.screenshot(path="jules-scratch/verification/desktop_preview_only_view.png")
+
+def verify_mobile_mode(page: Page):
+    """
+    Verifies the mobile preview toggle: edit -> preview.
+    """
+    print("\nVerifying mobile mode...")
+    page.set_viewport_size({"width": 375, "height": 667})
+    page.goto("http://localhost:4173")
+
+    # Create a note using the FAB
+    page.locator(".fab").click()
+    expect(page.locator(".editor-header")).to_be_visible()
+    page.locator(".content-textarea").fill("## Mobile Test\n\n- Item 1\n- Item 2")
+
+    # 1. Toggle to Preview View
+    preview_button = page.get_by_title("Preview mode")
+    preview_button.click()
+    expect(page.locator(".markdown-preview-wrapper")).to_be_visible()
+    expect(page.locator(".content-textarea")).not_to_be_visible()
+    print("Taking screenshot of mobile preview...")
+    page.screenshot(path="jules-scratch/verification/mobile_preview_view.png")
+
+def main():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+
+        verify_desktop_modes(page)
+        verify_mobile_mode(page)
+
+        browser.close()
+    print("\nVerification script finished successfully.")
+
+if __name__ == "__main__":
+    main()

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -238,10 +238,20 @@ class UIStore {
   theme: 'dark' | 'light' | 'typewriter' | 'minimal' | 'dark-typewriter' | 'green-terminal' | 'amber-noir' | 'indigo-typewriter' | 'everforest-transparent' | 'tokyo-night-transparent' | 'gruvbox-transparent' = $state('dark')
   font: string = $state('courier-prime')
   fontSize: number = $state(16)
-  markdownPreview: boolean = $state(false)
+  previewMode: 'edit' | 'split' | 'preview' = $state('edit')
 
-  toggleMarkdownPreview() {
-    this.markdownPreview = !this.markdownPreview
+  // Cycle through preview modes intelligently
+  cyclePreviewMode() {
+    if (this.isMobile) {
+      // On mobile, just toggle between edit and full preview
+      this.previewMode = this.previewMode === 'edit' ? 'preview' : 'edit';
+    } else {
+      // On desktop, cycle through edit -> split -> preview -> edit
+      const modes: Array<'edit' | 'split' | 'preview'> = ['edit', 'split', 'preview'];
+      const currentIndex = modes.indexOf(this.previewMode);
+      const nextIndex = (currentIndex + 1) % modes.length;
+      this.previewMode = modes[nextIndex];
+    }
   }
 
   toggleSidebar() {


### PR DESCRIPTION
This commit introduces a significantly improved Markdown preview experience with different modes for desktop and mobile, ensuring a more productive and responsive workflow.

Key changes:
- **Refactored UI Store**: Replaced the simple `markdownPreview` boolean with a more flexible `previewMode: 'edit' | 'split' | 'preview'` state in `UIStore`.
- **Intelligent Mode Cycling**: Added a `cyclePreviewMode()` method that provides a `edit -> split -> preview` cycle on desktop and a simple `edit -> preview` toggle on mobile.
- **Split-Screen for Desktop**: Implemented a side-by-side view in `Editor.svelte` that allows users on larger screens to see their Markdown source and the rendered preview simultaneously.
- **Responsive Mobile View**: Ensured that on mobile devices, the preview toggles cleanly between a full-screen editor and a full-screen preview for optimal use of limited space.
- **Dynamic Button UI**: The preview button now dynamically updates its icon and tooltip to reflect the next available mode (e.g., showing a split-view icon, an eye icon, or a pencil icon).
- **TypeScript Fix**: Corrected an issue with accessing `$derived` state in Svelte 5, ensuring the component compiles correctly.